### PR TITLE
feat: automated the run and build process, added runtime for all os builds and detection and removed rust unused crates

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -5,25 +5,29 @@
 
 set shell := ["bash", "-uc"]
 
+rust_target := `case "$(uname -s):$(uname -m)" in Darwin:arm64) echo aarch64-apple-darwin ;; Darwin:x86_64) echo x86_64-apple-darwin ;; Linux:arm64|Linux:aarch64) echo aarch64-unknown-linux-gnu ;; Linux:x86_64) echo x86_64-unknown-linux-gnu ;; MINGW*:x86_64|MSYS*:x86_64|CYGWIN*:x86_64) echo x86_64-pc-windows-gnu ;; *) echo unsupported-target >&2; exit 1 ;; esac`
+linux_rust_target := `case "$(uname -m)" in arm64|aarch64) echo aarch64-unknown-linux-gnu ;; x86_64) echo x86_64-unknown-linux-gnu ;; *) echo unsupported-linux-arch >&2; exit 1 ;; esac`
+macos_rust_target := `case "$(uname -m)" in arm64|aarch64) echo aarch64-apple-darwin ;; x86_64) echo x86_64-apple-darwin ;; *) echo unsupported-macos-arch >&2; exit 1 ;; esac`
+
 # Default target - build and run benchmark
 default: run
 
 # Build Rust static library
 build-rust:
-    @echo "🔨 Building Rust library..."
-    cd rust && cargo build --release --target x86_64-pc-windows-gnu
+    @echo "🔨 Building Rust library for {{rust_target}}..."
+    cd rust && RUSTFLAGS="-C target-cpu=native" cargo build --release --target {{rust_target}}
     @echo "✅ Rust library built"
 
 # Build Rust for Linux
 build-rust-linux:
-    @echo "🔨 Building Rust library for Linux..."
-    cd rust && cargo build --release --target x86_64-unknown-linux-gnu
+    @echo "🔨 Building Rust library for Linux target {{linux_rust_target}}..."
+    cd rust && RUSTFLAGS="-C target-cpu=native" cargo build --release --target {{linux_rust_target}}
     @echo "✅ Rust library built"
 
 # Build Rust for macOS
 build-rust-macos:
-    @echo "🔨 Building Rust library for macOS..."
-    cd rust && cargo build --release --target x86_64-apple-darwin
+    @echo "🔨 Building Rust library for macOS target {{macos_rust_target}}..."
+    cd rust && RUSTFLAGS="-C target-cpu=native" cargo build --release --target {{macos_rust_target}}
     @echo "✅ Rust library built"
 
 # Clean all build artifacts
@@ -37,36 +41,36 @@ clean:
 # Build Zig benchmark (Debug)
 build-debug: build-rust
     @echo "🔨 Building Zig benchmark (Debug)..."
-    zig build -Dtarget=x86_64-windows-gnu
+    zig build
 
 # Build Zig benchmark (ReleaseFast)
 build-release: build-rust
     @echo "🔨 Building Zig benchmark (ReleaseFast)..."
-    zig build -Dtarget=x86_64-windows-gnu -Doptimize=ReleaseFast
+    zig build -Doptimize=ReleaseFast
 
 # Run benchmark (Debug)
 run-debug: build-debug
     @echo "🚀 Running benchmark (Debug)..."
-    zig build -Dtarget=x86_64-windows-gnu run
+    zig build run
 
 # Run benchmark (ReleaseFast)
 run: build-release
     @echo "🚀 Running benchmark (ReleaseFast)..."
-    zig build -Dtarget=x86_64-windows-gnu -Doptimize=ReleaseFast run
+    zig build -Doptimize=ReleaseFast run
 
 # Run benchmark multiple times for stats
 bench: build-release
     @echo "📊 Running benchmark 5 times..."
     @for i in 1 2 3 4 5; do \
         echo "\n--- Run $$i ---"; \
-        zig build -Dtarget=x86_64-windows-gnu -Doptimize=ReleaseFast run; \
+        zig build -Doptimize=ReleaseFast run; \
     done
 
 # Run with different matrix sizes
 bench-sizes: build-release
     @echo "📊 Benchmarking different matrix sizes..."
     @echo "100x50 * 50x100"
-    @zig build -Dtarget=x86_64-windows-gnu -Doptimize=ReleaseFast run
+    @zig build -Doptimize=ReleaseFast run
     @echo "\n200x100 * 100x200"
     @# Modify matrix sizes in bench.zig or use build options
     @echo "Run with modified matrix sizes"
@@ -74,7 +78,7 @@ bench-sizes: build-release
 # Quick check (fast compile, no Rust rebuild if exists)
 quick: build-rust
     @echo "🔨 Quick build (cached)..."
-    zig build -Dtarget=x86_64-windows-gnu -Doptimize=ReleaseFast run
+    zig build -Doptimize=ReleaseFast run
 
 # Watch mode (requires watchexec)
 watch:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # matrix-lib: A Polyglot Systems Performance Journey
 
-> *"In systems engineering, we don't just write code that works. We write code that vibrates with the hardware."*
+> _"In systems engineering, we don't just write code that works. We write code that vibrates with the hardware."_
 
 ---
 
@@ -8,33 +8,33 @@
 ╔══════════════════════════════════════════════════════════════════════╗
 ║                    THE POLYGLOT ENGINE                               ║
 ║                                                                      ║
-║   Your Application Code (Python / Go / TypeScript / Node.js)        ║
+║   Your Application Code (Python / Go / TypeScript / Node.js)         ║
 ║          │                                                           ║
 ║          ▼                                                           ║
-║   ┌──────────────────────────────────────────┐                      ║
-║   │         C  A B I  B o u n d a r y        │  ← Zero-overhead     ║
-║   └──────────────────────────────────────────┘     FFI calls        ║
-║          │               │               │                          ║
-║          ▼               ▼               ▼                          ║
-║      ┌───────┐       ┌───────┐       ┌───────┐                      ║
-║      │  Zig  │       │ Rust  │       │  C++  │  ← Compute Kernels   ║
-║      │ 865ms │       │ 647ms │       │ 401ms │                      ║
-║      └───────┘       └───────┘       └───────┘                      ║
-║          │               │               │                          ║
-║          └───────────────┼───────────────┘                          ║
+║   ┌──────────────────────────────────────────┐                       ║
+║   │         C  A B I  B o u n d a r y        │  ← Zero-overhead      ║
+║   └──────────────────────────────────────────┘     FFI calls         ║
+║          │               │               │                           ║
+║          ▼               ▼               ▼                           ║
+║      ┌───────┐       ┌───────┐       ┌───────┐                       ║
+║      │  Zig  │       │ Rust  │       │  C++  │  ← Compute Kernels    ║
+║      │ 865ms │       │ 647ms │       │ 401ms │                       ║
+║      └───────┘       └───────┘       └───────┘                       ║
+║          │               │               │                           ║
+║          └───────────────┼───────────────┘                           ║
 ║                          ▼                                           ║
-║          ┌────────────────────────────────┐                         ║
-║          │   Zig Build System (build.zig) │  ← Unified Orchestrator ║
-║          │   Compiles C++, links Rust     │                         ║
-║          │   .a staticlib, resolves all   │                         ║
-║          │   Windows system deps          │                         ║
-║          └────────────────────────────────┘                         ║
+║          ┌────────────────────────────────┐                          ║
+║          │   Zig Build System (build.zig) │  ← Unified Orchestrator  ║
+║          │   Compiles C++, links Rust     │                          ║
+║          │   .a staticlib, resolves all   │                          ║
+║          │   Windows system deps          │                          ║
+║          └────────────────────────────────┘                          ║
 ║                          │                                           ║
 ║                          ▼                                           ║
-║          ┌────────────────────────────────┐                         ║
-║          │   Single Benchmark Binary      │                         ║
-║          │   bench.exe                    │                         ║
-║          └────────────────────────────────┘                         ║
+║          ┌────────────────────────────────┐                          ║
+║          │   Single Benchmark Binary      │                          ║
+║          │   bench.exe                    │                          ║
+║          └────────────────────────────────┘                          ║
 ╚══════════════════════════════════════════════════════════════════════╝
 ```
 
@@ -53,7 +53,7 @@ The journey produced four major insights that apply to every high-performance sy
 1. **RAM is a flat, 1D tape.** Your 2D mental model of a matrix is a lie the language tells you for convenience. The moment you write code that fights this reality, you lose.
 2. **Cache lines are the unit of memory currency.** The CPU doesn't buy floats from RAM one at a time. It buys 16 at once. If you only use 1 of those 16, you wasted 94% of your memory bandwidth.
 3. **Compiler flags are load-bearing architecture.** `-ffast-math` is not cosmetic. It unlocks an entirely different class of machine code (AVX2 vectorization). Without it, your code and the machine code are nearly unrecognizable as siblings.
-4. **Manual optimization can fight the compiler.** In Stage 4, adding cache-blocking code actually *regressed* Zig by 58%. The compiler was auto-vectorizing the simple loop perfectly. Our "smart" manual tiling broke its ability to prove the loop was safe to vectorize.
+4. **Manual optimization can fight the compiler.** In Stage 4, adding cache-blocking code actually _regressed_ Zig by 58%. The compiler was auto-vectorizing the simple loop perfectly. Our "smart" manual tiling broke its ability to prove the loop was safe to vectorize.
 
 If you absorb these four lessons, you will think differently about every loop you write for the rest of your career.
 
@@ -70,14 +70,17 @@ The CPU used for all benchmarks is an **Intel Core i5-6300U** (Skylake microarch
 ## The Languages and What They Represent
 
 ### Zig — The Modern Systems Glue
-Zig is the "new C." It gives you manual memory control, zero hidden allocations, and no runtime. What makes Zig unique in this project is that it serves **dual roles**: it is both one of the three compute kernels *and* the build system that orchestrates the entire project. `build.zig` replaces `CMakeLists.txt`, `Makefile`, and shell scripts. It compiles C++ source files, links Rust `.a` static libraries, and resolves Windows system dependencies — all in one coherent, programmable build description.
+
+Zig is the "new C." It gives you manual memory control, zero hidden allocations, and no runtime. What makes Zig unique in this project is that it serves **dual roles**: it is both one of the three compute kernels _and_ the build system that orchestrates the entire project. `build.zig` replaces `CMakeLists.txt`, `Makefile`, and shell scripts. It compiles C++ source files, links Rust `.a` static libraries, and resolves Windows system dependencies — all in one coherent, programmable build description.
 
 Zig's `comptime` (compile-time execution) means that zero-cost abstractions aren't just a goal; they're enforced by the type system. There is no runtime cost for generic code in Zig.
 
 ### Rust — The Memory-Safe Performance Contender
+
 Rust's ownership model gives the compiler a formally-verified understanding of pointer aliasing. In theory, this should allow extremely aggressive LLVM optimization. In practice, the safety abstractions (safe slices with implicit bounds checks) introduced overhead in Stage 1. Once we stripped those abstractions and worked with raw pointers in `unsafe` blocks (Stage 3), Rust found its footing and eventually achieved its best result with cache-blocked tiling in Stage 4 (647ms).
 
 ### C++ — The Veteran
+
 C++ has decades of production use and its compiler ecosystem (GCC, Clang, MSVC) is extraordinarily mature. With the right flags (`-O3 -march=native -ffast-math -funroll-loops`), `g++ 15.2.0` consistently produced the fastest binary in this benchmark. This is not because C++ is "faster" as a language — it's because the GCC optimizer for this specific workload and this specific CPU has extremely well-tuned heuristics for loop unrolling and AVX2 code generation.
 
 ---
@@ -85,28 +88,30 @@ C++ has decades of production use and its compiler ecosystem (GCC, Clang, MSVC) 
 ## Performance Results — The Full Picture
 
 ### Environment
-| Factor | Value |
-|:---|:---|
-| OS | Windows 11 (MSYS2/MinGW64) |
-| CPU | Intel Core i5-6300U (Skylake, x86_64) |
-| L1 Cache | 32 KB data / core |
-| L2 Cache | 256 KB / core |
-| L3 Cache | 3 MB shared |
-| Cache Line Size | 64 bytes = 16 × f32 |
-| Zig Version | 0.15.2 |
-| Rust Version | 1.93.1 (x86_64-pc-windows-gnu) |
-| C++ Compiler | g++ 15.2.0 (x86_64-w64-mingw32) |
+
+| Factor          | Value                                 |
+| :-------------- | :------------------------------------ |
+| OS              | Windows 11 (MSYS2/MinGW64)            |
+| CPU             | Intel Core i5-6300U (Skylake, x86_64) |
+| L1 Cache        | 32 KB data / core                     |
+| L2 Cache        | 256 KB / core                         |
+| L3 Cache        | 3 MB shared                           |
+| Cache Line Size | 64 bytes = 16 × f32                   |
+| Zig Version     | 0.15.2                                |
+| Rust Version    | 1.93.1 (x86_64-pc-windows-gnu)        |
+| C++ Compiler    | g++ 15.2.0 (x86_64-w64-mingw32)       |
 
 ### Summary Table — 1024×1024 × 1024×1024 (≈2.1 billion FLOPs)
 
-| Stage | What Changed | Zig | Rust | C++ | Key Insight |
-|:---|:---|:---:|:---:|:---:|:---|
-| **1** | Naive `(i,j,k)` loops | 10,414ms | 12,826ms | 12,820ms | Default flags favor Zig |
-| **2** | Added `-march=native -ffast-math` to C++ | 13,466ms | 12,685ms | 10,671ms | Flags flip the leader |
-| **3** | Reordered to `(i,k,j)` loops | 865ms | 785ms | 419ms | **Algorithm dominates everything** |
-| **4** | 64×64 cache-blocked tiling | 1,367ms | 647ms | 401ms | Manual opt can hurt the compiler |
+| Stage | What Changed                             |   Zig    |   Rust   |   C++    | Key Insight                        |
+| :---- | :--------------------------------------- | :------: | :------: | :------: | :--------------------------------- |
+| **1** | Naive `(i,j,k)` loops                    | 10,414ms | 12,826ms | 12,820ms | Default flags favor Zig            |
+| **2** | Added `-march=native -ffast-math` to C++ | 13,466ms | 12,685ms | 10,671ms | Flags flip the leader              |
+| **3** | Reordered to `(i,k,j)` loops             |  865ms   |  785ms   |  419ms   | **Algorithm dominates everything** |
+| **4** | 64×64 cache-blocked tiling               | 1,367ms  |  647ms   |  401ms   | Manual opt can hurt the compiler   |
 
 > **Total peak improvement over the naive baseline:**
+>
 > - C++: **32×** faster (12,820ms → 401ms)
 > - Rust: **19.8×** faster (12,826ms → 647ms)
 > - Zig (best): **13.3×** faster (10,414ms → 785ms in Stage 3)
@@ -133,7 +138,7 @@ This is the most important optimization insight in this entire project. The phys
 
 In Stage 4, we manually implemented cache-blocking/tiling — a technique from the BLAS literature used by libraries like OpenBLAS and Intel MKL. For Rust, it helped (-17%). For C++, it barely mattered (-4%). For Zig, it **hurt badly** (+58% slower).
 
-Why? Because the simple `(i,k,j)` loop we had in Stage 3 was a clean, analyzable pattern that LLVM's auto-vectorizer could recognize. The tiled version added `@min()` bounds checks and extra loop variables that introduced branching complexity. The vectorizer could no longer *prove* the inner loop was safe to turn into AVX2 instructions, so it backed off to scalar code. We got in the compiler's way.
+Why? Because the simple `(i,k,j)` loop we had in Stage 3 was a clean, analyzable pattern that LLVM's auto-vectorizer could recognize. The tiled version added `@min()` bounds checks and extra loop variables that introduced branching complexity. The vectorizer could no longer _prove_ the inner loop was safe to turn into AVX2 instructions, so it backed off to scalar code. We got in the compiler's way.
 
 ### Lesson 4: `-ffast-math` Is Not Just a Flag. It Is a Different Contract.
 
@@ -146,20 +151,24 @@ For scientific computation requiring reproducible floating-point results (weathe
 ## Build and Replicate
 
 ### Prerequisites
+
 - **Zig 0.15.2** — [ziglang.org/download](https://ziglang.org/download)
 - **Rust** with `x86_64-pc-windows-gnu` target — `rustup target add x86_64-pc-windows-gnu`
 - **G++ 15.2.0** via MSYS2/MinGW64
 
 ### Step 1: Build the Rust Static Library
+
 ```bash
 cd rust
 # -C target-cpu=native tells rustc to use your CPU's specific instruction set
 RUSTFLAGS="-C target-cpu=native" cargo build --release --target x86_64-pc-windows-gnu
 cd ..
 ```
+
 This produces `rust/target/x86_64-pc-windows-gnu/release/libmatrix_rs.a` — a static archive that Zig will link at compile time.
 
 ### Step 2: Build and Run
+
 ```bash
 # Remove all cached build artifacts (important for accurate timing)
 zig build clean
@@ -169,7 +178,13 @@ zig build clean
 zig build run -Doptimize=ReleaseFast -Dtarget=native
 ```
 
+```bash
+you can also export the run_benchmark_stages.sh using chmod and then run ./run_benchmark_stages.sh
+note that this eventually runs the stages based on the gittrees for the code at the commit, so if you update the codebase only stage 4 gets updated.
+```
+
 ### Expected Output
+
 ```
 === Matrix Multiplication Benchmark (1024x1024 * 1024x1024) ===
 Zig:  1367 ms
@@ -182,10 +197,10 @@ Results match: true
 
 ## Deep Documentation Index
 
-| Document | What It Covers |
-|:---|:---|
-| **[DEEP_DIVE.md](./DEEP_DIVE.md)** | The physics of RAM, cache lines, stride, SIMD, and why loop order is your most important design decision. Read this to understand *why* the numbers are what they are. |
-| **[PERFORMANCE_LOG.md](./PERFORMANCE_LOG.md)** | The full, auditable changelog: every code change, every flag added, every result measured. Read this to follow the investigation step by step. |
+| Document                                       | What It Covers                                                                                                                                                         |
+| :--------------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **[DEEP_DIVE.md](./DEEP_DIVE.md)**             | The physics of RAM, cache lines, stride, SIMD, and why loop order is your most important design decision. Read this to understand _why_ the numbers are what they are. |
+| **[PERFORMANCE_LOG.md](./PERFORMANCE_LOG.md)** | The full, auditable changelog: every code change, every flag added, every result measured. Read this to follow the investigation step by step.                         |
 
 ---
 
@@ -232,24 +247,24 @@ During repeated benchmarking runs, performance results vary significantly even w
 
 Example observed results:
 
-Zig:  748 ms → 158 ms → 178 ms → 164 ms → 176 ms  
+Zig: 748 ms → 158 ms → 178 ms → 164 ms → 176 ms  
 Rust: 719 ms → 174 ms → 186 ms → 211 ms → 234 ms  
-C++:  367 ms → 152 ms → 170 ms → 182 ms
+C++: 367 ms → 152 ms → 170 ms → 182 ms
 
 ### Why this happens
 
 Matrix multiplication performance is heavily influenced by **CPU state**, not just code:
 
--   **Cache warmth (L1/L2/L3):**  
-    Data may already be cached from previous runs, making execution significantly faster.
--   **Cache eviction:**  
-    Background processes (browser, OS services) can evict hot data from cache, causing slowdowns.
--   **Branch predictor & prefetcher state:**  
-    Modern CPUs “learn” memory access patterns over time, improving or degrading performance between runs.
--   **OS scheduling noise:**  
-    CPU time is shared with system processes, introducing variability.
+- **Cache warmth (L1/L2/L3):**  
+  Data may already be cached from previous runs, making execution significantly faster.
+- **Cache eviction:**  
+  Background processes (browser, OS services) can evict hot data from cache, causing slowdowns.
+- **Branch predictor & prefetcher state:**  
+  Modern CPUs “learn” memory access patterns over time, improving or degrading performance between runs.
+- **OS scheduling noise:**  
+  CPU time is shared with system processes, introducing variability.
 
-* * *
+---
 
 ### Key Insight
 
@@ -257,34 +272,35 @@ Matrix multiplication performance is heavily influenced by **CPU state**, not ju
 
 Matrix multiplication performance is dominated by:
 
--   How efficiently data fits into cache lines (typically 64 bytes)
--   Whether memory access is sequential or strided
--   How often the CPU must fetch from L2/L3 or RAM
+- How efficiently data fits into cache lines (typically 64 bytes)
+- Whether memory access is sequential or strided
+- How often the CPU must fetch from L2/L3 or RAM
 
-* * *
+---
 
 ### Practical Conclusion
 
 Small code changes may not matter as much as:
 
--   Memory access patterns
--   Cache reuse efficiency
--   Data layout in memory
+- Memory access patterns
+- Cache reuse efficiency
+- Data layout in memory
 
 In high-performance systems, the goal is:
 
 > **Minimize cache misses and maximize reuse per cache line fetched.**
 
-* * *
+---
 
 ### Implication for this project
 
 This benchmark demonstrates that:
 
--   Language choice alone is not the primary performance factor
--   Compiler optimizations and memory access patterns dominate runtime behavior
--   Real-world performance must be measured across multiple runs, not single executions
+- Language choice alone is not the primary performance factor
+- Compiler optimizations and memory access patterns dominate runtime behavior
+- Real-world performance must be measured across multiple runs, not single executions
 
 ---
 
-*Built on an i5-6300U in Juja, Kenya. Proof that world-class systems engineering doesn't require a FAANG badge — just the willingness to read what the hardware is trying to tell you.*
+_Built on an i5-6300U in Juja, Kenya. Proof that world-class systems engineering doesn't require a FAANG badge — just the willingness to read what the hardware is trying to tell you._
+

--- a/build.zig
+++ b/build.zig
@@ -27,7 +27,7 @@ pub fn build(b: *std.Build) void {
         },
     });
     bench.addIncludePath(b.path("cpp"));
-    bench.linkSystemLibrary("stdc++");
+    bench.linkSystemLibrary(cppRuntimeFor(target));
 
     // Compile and link Zig implementation
     const zig_obj = b.addObject(.{
@@ -41,7 +41,10 @@ pub fn build(b: *std.Build) void {
     bench.addObject(zig_obj);
 
     // Link Rust static library
-    const rust_lib_path = "rust/target/x86_64-pc-windows-gnu/release/libmatrix_rs.a";
+    const rust_lib_path = b.fmt(
+        "rust/target/{s}/release/libmatrix_rs.a",
+        .{rustTargetTriple(target)},
+    );
     bench.addObjectFile(b.path(rust_lib_path));
 
     // Windows-specific libraries for Rust/C++ interop
@@ -74,4 +77,41 @@ pub fn build(b: *std.Build) void {
             std.fs.cwd().deleteTree(path2) catch {};
         }
     }.make;
+}
+// Add support for apple's stdc++
+fn cppRuntimeFor(target: std.Build.ResolvedTarget) []const u8 {
+    return switch (target.result.os.tag) {
+        .macos => "c++",
+        else => "stdc++",
+    };
+}
+// logic for auto detection at compile time.
+fn rustTargetTriple(target: std.Build.ResolvedTarget) []const u8 {
+    return switch (target.result.os.tag) {
+        .linux => switch (target.result.cpu.arch) {
+            .aarch64 => "aarch64-unknown-linux-gnu",
+            .x86_64 => "x86_64-unknown-linux-gnu",
+            else => unsupportedRustTarget(target),
+        },
+        .macos => switch (target.result.cpu.arch) {
+            .aarch64 => "aarch64-apple-darwin",
+            .x86_64 => "x86_64-apple-darwin",
+            else => unsupportedRustTarget(target),
+        },
+        .windows => switch (target.result.cpu.arch) {
+            .x86_64 => "x86_64-pc-windows-gnu",
+            else => unsupportedRustTarget(target),
+        },
+        else => unsupportedRustTarget(target),
+    };
+}
+// just in case someone run it on another os not like i know who will though haha
+fn unsupportedRustTarget(target: std.Build.ResolvedTarget) noreturn {
+    std.debug.panic(
+        "unsupported target for Rust static library: {s}-{s}",
+        .{
+            @tagName(target.result.cpu.arch),
+            @tagName(target.result.os.tag),
+        },
+    );
 }

--- a/run_benchmark_stages.sh
+++ b/run_benchmark_stages.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/matrix-stages.XXXXXX")"
+KEEP_WORKTREES="${KEEP_WORKTREES:-0}"
+
+declare -a WORKTREES=()
+
+require_cmd() {
+    command -v "$1" >/dev/null 2>&1 || {
+        printf 'missing command: %s\n' "$1" >&2
+        exit 1
+    }
+}
+
+detect_host() {
+    case "$(uname -s):$(uname -m)" in
+        Darwin:arm64|Darwin:aarch64)
+            RUST_TARGET="aarch64-apple-darwin"
+            CXX_RUNTIME="c++"
+            ;;
+        Darwin:x86_64)
+            RUST_TARGET="x86_64-apple-darwin"
+            CXX_RUNTIME="c++"
+            ;;
+        Linux:arm64|Linux:aarch64)
+            RUST_TARGET="aarch64-unknown-linux-gnu"
+            CXX_RUNTIME="stdc++"
+            ;;
+        Linux:x86_64)
+            RUST_TARGET="x86_64-unknown-linux-gnu"
+            CXX_RUNTIME="stdc++"
+            ;;
+        *)
+            printf 'unsupported host: %s:%s\n' "$(uname -s)" "$(uname -m)" >&2
+            exit 1
+            ;;
+    esac
+}
+
+cleanup() {
+    local exit_code=$?
+
+    if [[ "$KEEP_WORKTREES" != "1" ]]; then
+        for worktree in "${WORKTREES[@]}"; do
+            git -C "$ROOT_DIR" worktree remove --force "$worktree" >/dev/null 2>&1 || true
+        done
+        rm -rf "$TMP_ROOT"
+    else
+        printf 'kept worktrees in %s\n' "$TMP_ROOT" >&2
+    fi
+
+    exit "$exit_code"
+}
+
+trap cleanup EXIT
+
+add_worktree() {
+    local name="$1"
+    local commit="$2"
+    local dir="$TMP_ROOT/$name"
+
+    git -C "$ROOT_DIR" worktree add --detach "$dir" "$commit" >/dev/null
+    WORKTREES+=("$dir")
+    printf '%s\n' "$dir"
+}
+
+patch_stage1_build() {
+    local dir="$1"
+
+    sed -i.bak \
+        -e "s|x86_64-apple-darwin|${RUST_TARGET}|g" \
+        -e "s|x86_64-unknown-linux-gnu|${RUST_TARGET}|g" \
+        -e "s|bench.linkSystemLibrary(\"stdc++\");|bench.linkSystemLibrary(\"${CXX_RUNTIME}\");|" \
+        "$dir/build.zig"
+
+    rm -f "$dir/build.zig.bak"
+}
+
+prepare_modern_build() {
+    local dir="$1"
+    cp "$ROOT_DIR/build.zig" "$dir/build.zig"
+}
+
+prepare_rust_crate_root() {
+    local dir="$1"
+    cp "$ROOT_DIR/rust/src/lib.rs" "$dir/rust/src/lib.rs"
+}
+
+build_rust() {
+    local dir="$1"
+    local rustflags="$2"
+
+    if [[ -n "$rustflags" ]]; then
+        (
+            cd "$dir/rust"
+            RUSTFLAGS="$rustflags" cargo build --release --target "$RUST_TARGET"
+        )
+    else
+        (
+            cd "$dir/rust"
+            cargo build --release --target "$RUST_TARGET"
+        )
+    fi
+}
+
+run_zig() {
+    local dir="$1"
+    shift
+
+    (
+        cd "$dir"
+        zig build run "$@"
+    )
+}
+
+run_stage() {
+    local label="$1"
+    local commit="$2"
+    local rustflags="$3"
+    shift 3
+
+    local dir
+    printf '\n=== %s (%s) ===\n' "$label" "$commit"
+    dir="$(add_worktree "$label" "$commit")"
+
+    if [[ "$label" == "stage1" ]]; then
+        patch_stage1_build "$dir"
+    else
+        prepare_modern_build "$dir"
+    fi
+
+    prepare_rust_crate_root "$dir"
+    build_rust "$dir" "$rustflags"
+    run_zig "$dir" "$@"
+}
+
+main() {
+    local cmd
+
+    for cmd in bash git rustup cargo zig sed cp mktemp uname; do
+        require_cmd "$cmd"
+    done
+
+    detect_host
+
+    printf 'Host target: %s\n' "$RUST_TARGET"
+    rustup target add "$RUST_TARGET"
+
+    run_stage stage1 f81426b "" -Doptimize=ReleaseFast
+    run_stage stage2 906609d "-C target-cpu=native" -Doptimize=ReleaseFast -Dtarget=native
+    run_stage stage3 c7c6d4c "-C target-cpu=native" -Doptimize=ReleaseFast -Dtarget=native
+    run_stage stage4 32f7d90 "-C target-cpu=native" -Doptimize=ReleaseFast -Dtarget=native
+}
+
+main "$@"

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod matrix;
-use crate::matrix::{rust_matrix_multiply, rust_matrix_add};
+// use crate::matrix::{rust_matrix_multiply, rust_matrix_add}; //commented out since the crate are
+// never refrenced or exported for usage.


### PR DESCRIPTION
Well funny enough was planning on optmizing the zig files but it looks okay but yeah I do plan to do so again, call me biased about zig but, yeah will do that later i first had to ensure to test it on all os and still on my mac zig is slower currently like here are the results 

./run_benchmark_stages.sh
Host target: aarch64-apple-darwin
info: component rust-std is up to date

=== stage1 (f81426b) ===
Preparing worktree (detached HEAD f81426b)
   Compiling matrix_rs v0.1.0 (/private/var/folders/ld/t3vw74f52_v25rf9379q6ht00000gn/T/matrix-stages.aGuQ6q/stage1/rust)
    Finished [`release` profile [optimized]](https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles) target(s) in 2.43s

=== Matrix Multiplication Benchmark (1024x1024 * 1024x1024) ===
Zig:  1020 ms
Rust: 1081 ms
C++:  1284 ms
Results match: true

=== stage2 (906609d) ===
Preparing worktree (detached HEAD 906609d)
   Compiling matrix_rs v0.1.0 (/private/var/folders/ld/t3vw74f52_v25rf9379q6ht00000gn/T/matrix-stages.aGuQ6q/stage2/rust)
    Finished [`release` profile [optimized]](https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles) target(s) in 2.06s

=== Matrix Multiplication Benchmark (1024x1024 * 1024x1024) ===
Zig:  1026 ms
Rust: 1084 ms
C++:  1263 ms
Results match: true

=== stage3 (c7c6d4c) ===
Preparing worktree (detached HEAD c7c6d4c)
   Compiling matrix_rs v0.1.0 (/private/var/folders/ld/t3vw74f52_v25rf9379q6ht00000gn/T/matrix-stages.aGuQ6q/stage3/rust)
    Finished [`release` profile [optimized]](https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles) target(s) in 1.94s

=== Matrix Multiplication Benchmark (1024x1024 * 1024x1024) ===
Zig:  89 ms
Rust: 83 ms
C++:  83 ms
Results match: true

=== stage4 (32f7d90) ===
Preparing worktree (detached HEAD 32f7d90)
   Compiling matrix_rs v0.1.0 (/private/var/folders/ld/t3vw74f52_v25rf9379q6ht00000gn/T/matrix-stages.aGuQ6q/stage4/rust)
    Finished [`release` profile [optimized]](https://doc.rust-lang.org/cargo/reference/profiles.html#default-profiles) target(s) in 2.06s

=== Matrix Multiplication Benchmark (1024x1024 * 1024x1024) ===
Zig:  144 ms
Rust: 126 ms
C++:  119 ms
Results match: true
./run_benchmark_stages.sh: line 42: WORKTREES[@]: unbound variable

this is based on the worktrees of early git commits no code chages for matrix